### PR TITLE
[Fix]#44 Single.subscribe시 onError메소드에 dataLoading 처리가 누락된 부분 수정

### DIFF
--- a/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/GalleryViewModel.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/GalleryViewModel.kt
@@ -73,6 +73,7 @@ class GalleryViewModel @Inject constructor(
                     else -> showToast(resourceProvider.getString(StringResourceProvider.StringResourceId.RemoveFail))
                 }
             }) {
+                _dataLoading.value = false
                 it.printStackTrace()
                 showToast(resourceProvider.getString(StringResourceProvider.StringResourceId.RemoveFail) + " $it")
             }.addTo(compositeDisposable)

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/SearchImageViewModel.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/SearchImageViewModel.kt
@@ -99,6 +99,7 @@ class SearchImageViewModel @Inject constructor(
                     else -> showToast(resourceProvider.getString(StringResourceProvider.StringResourceId.SaveFail))
                 }
             }) {
+                _dataLoading.value = false
                 it.printStackTrace()
                 showToast(resourceProvider.getString(StringResourceProvider.StringResourceId.SaveFail) + " $it")
             }.addTo(compositeDisposable)
@@ -117,6 +118,7 @@ class SearchImageViewModel @Inject constructor(
                 if (query.isNotEmpty()) _searchResultIsEmpty.value = it.size <= 1
                 _searchImages.value = it
             }) {
+                _dataLoading.value = false
                 when (it) {
                     is MaxPageException -> showToast(
                         resourceProvider.getString(
@@ -138,6 +140,7 @@ class SearchImageViewModel @Inject constructor(
                 val prevList = _searchImages.value ?: emptyList()
                 _searchImages.value = prevList + it
             }) {
+                _dataLoading.value = false
                 when (it) {
                     is MaxPageException -> showToast(
                         resourceProvider.getString(


### PR DESCRIPTION
## 📪  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #44 
## 📚  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] Usecase가 Single타입을 리턴한 경우 onError 메소드도 구현을 해줘야 하는데, onError메소드 구현중 dataLoading 처리가 누락된 부분 수정

closed #44 