### PR TITLE
[Refactor] Gallery에서 사용되는 ImageModel을 Entity와 Model로 분리 

### DIFF
--- a/app/src/main/java/com/gallery/kakaogallery/data/dao/SaveImageDao.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/data/dao/SaveImageDao.kt
@@ -1,12 +1,14 @@
 package com.gallery.kakaogallery.data.dao
 
+import com.gallery.kakaogallery.data.entity.local.ImageEntity
 import com.gallery.kakaogallery.domain.model.ImageModel
+import com.gallery.kakaogallery.domain.model.SearchImageModel
 import io.reactivex.rxjava3.core.Observable
 
 interface SaveImageDao {
-    fun fetchSaveImages(): Observable<List<ImageModel>>
+    fun fetchSaveImages(): Observable<List<ImageEntity>>
 
     fun removeImages(idxList: List<Int>)
 
-    fun saveImages(image: List<ImageModel>)
+    fun saveImages(image: List<SearchImageModel>, saveDateTimeMill: Long)
 }

--- a/app/src/main/java/com/gallery/kakaogallery/data/dao/SaveImageDaoImpl.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/data/dao/SaveImageDaoImpl.kt
@@ -53,12 +53,9 @@ class SaveImageDaoImpl @Inject constructor(
         val list = (saveImagesSubject.value?.toMutableList() ?: mutableListOf()).apply {
             addAll(
                 image.toList().map {
-                    ImageEntity(
-                        it.imageUrl,
-                        it.imageThumbUrl,
-                        saveDateTimeMill,
-                        it.dateTimeMill,
-                        it.isImageType
+                    ImageEntity.from(
+                        it,
+                        saveDateTimeMill
                     )
                 }
             )

--- a/app/src/main/java/com/gallery/kakaogallery/data/datasource/SaveImageDataSource.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/data/datasource/SaveImageDataSource.kt
@@ -1,13 +1,15 @@
 package com.gallery.kakaogallery.data.datasource
 
+import com.gallery.kakaogallery.data.entity.local.ImageEntity
 import com.gallery.kakaogallery.domain.model.ImageModel
+import com.gallery.kakaogallery.domain.model.SearchImageModel
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Observable
 
 interface SaveImageDataSource {
-    fun fetchSaveImages(): Observable<List<ImageModel>>
+    fun fetchSaveImages(): Observable<List<ImageEntity>>
 
     fun removeImages(idxList: List<Int>): Completable
 
-    fun saveImages(image: List<ImageModel>): Completable
+    fun saveImages(image: List<SearchImageModel>, saveDateTimeMill: Long): Completable
 }

--- a/app/src/main/java/com/gallery/kakaogallery/data/datasource/SaveImageDataSourceImpl.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/data/datasource/SaveImageDataSourceImpl.kt
@@ -1,7 +1,9 @@
 package com.gallery.kakaogallery.data.datasource
 
 import com.gallery.kakaogallery.data.dao.SaveImageDao
+import com.gallery.kakaogallery.data.entity.local.ImageEntity
 import com.gallery.kakaogallery.domain.model.ImageModel
+import com.gallery.kakaogallery.domain.model.SearchImageModel
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.schedulers.Schedulers
@@ -11,7 +13,7 @@ class SaveImageDataSourceImpl @Inject constructor(
     private val saveImageDao: SaveImageDao
 ) : SaveImageDataSource {
 
-    override fun fetchSaveImages(): Observable<List<ImageModel>> {
+    override fun fetchSaveImages(): Observable<List<ImageEntity>> {
         return saveImageDao.fetchSaveImages()
             .subscribeOn(Schedulers.io())
     }
@@ -22,9 +24,9 @@ class SaveImageDataSourceImpl @Inject constructor(
         }.subscribeOn(Schedulers.io())
     }
 
-    override fun saveImages(image: List<ImageModel>): Completable {
+    override fun saveImages(image: List<SearchImageModel>, saveDateTimeMill: Long): Completable {
         return Completable.fromCallable {
-            saveImageDao.saveImages(image)
+            saveImageDao.saveImages(image, saveDateTimeMill)
         }.subscribeOn(Schedulers.io())
     }
 }

--- a/app/src/main/java/com/gallery/kakaogallery/data/entity/local/ImageEntity.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/data/entity/local/ImageEntity.kt
@@ -1,0 +1,23 @@
+package com.gallery.kakaogallery.data.entity.local
+
+import com.gallery.kakaogallery.domain.model.GalleryImageModel
+import com.gallery.kakaogallery.domain.model.ImageModel
+
+data class ImageEntity(
+    val imageUrl: String,
+    private val thumbnailUrl: String?,
+    val saveDateTimeMill: Long,
+    val imageDateTimeMill: Long?,
+    val isImageType: Boolean
+) {
+    fun toModel(
+        dateTimeToShow: String
+    ): GalleryImageModel {
+        return GalleryImageModel(
+            dateTimeToShow = dateTimeToShow,
+            imageUrl = imageUrl,
+            thumbnailUrl = thumbnailUrl,
+            imageType = if(isImageType) ImageModel.ImageType.Image else ImageModel.ImageType.Video
+        )
+    }
+}

--- a/app/src/main/java/com/gallery/kakaogallery/data/entity/local/ImageEntity.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/data/entity/local/ImageEntity.kt
@@ -2,6 +2,7 @@ package com.gallery.kakaogallery.data.entity.local
 
 import com.gallery.kakaogallery.domain.model.GalleryImageModel
 import com.gallery.kakaogallery.domain.model.ImageModel
+import com.gallery.kakaogallery.domain.model.SearchImageModel
 
 data class ImageEntity(
     val imageUrl: String,
@@ -10,6 +11,21 @@ data class ImageEntity(
     val imageDateTimeMill: Long?,
     val isImageType: Boolean
 ) {
+    companion object {
+        val Empty: ImageEntity
+            get() = ImageEntity("", null, 0L, null, true)
+
+        fun from(
+            searchImageModel: SearchImageModel,
+            saveDateTimeMill: Long
+        ) = ImageEntity(
+            imageUrl = searchImageModel.imageUrl,
+            thumbnailUrl = searchImageModel.imageThumbUrl,
+            saveDateTimeMill = saveDateTimeMill,
+            imageDateTimeMill = searchImageModel.dateTimeMill,
+            isImageType = searchImageModel.isImageType
+        )
+    }
     fun toModel(
         dateTimeToShow: String
     ): GalleryImageModel {

--- a/app/src/main/java/com/gallery/kakaogallery/data/entity/remote/response/ImageSearchResponse.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/data/entity/remote/response/ImageSearchResponse.kt
@@ -2,6 +2,7 @@ package com.gallery.kakaogallery.data.entity.remote.response
 
 
 import com.gallery.kakaogallery.domain.model.ImageModel
+import com.gallery.kakaogallery.domain.model.SearchImageModel
 import com.google.gson.annotations.SerializedName
 
 data class ImageSearchResponse(
@@ -31,11 +32,12 @@ data class ImageSearchResponse(
         fun toModel(
             dateTimeToShow: String,
             dateTimeMill: Long
-        ): ImageModel = ImageModel(
+        ): SearchImageModel = SearchImageModel(
             dateTimeToShow = dateTimeToShow,
             dateTimeMill = dateTimeMill,
             imageUrl = imageUrl,
-            thumbnailUrl = thumbnailUrl
+            thumbnailUrl = thumbnailUrl,
+            imageType = ImageModel.ImageType.Image
         )
     }
 

--- a/app/src/main/java/com/gallery/kakaogallery/data/entity/remote/response/VideoSearchResponse.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/data/entity/remote/response/VideoSearchResponse.kt
@@ -2,6 +2,7 @@ package com.gallery.kakaogallery.data.entity.remote.response
 
 
 import com.gallery.kakaogallery.domain.model.ImageModel
+import com.gallery.kakaogallery.domain.model.SearchImageModel
 import com.google.gson.annotations.SerializedName
 
 data class VideoSearchResponse(
@@ -27,11 +28,12 @@ data class VideoSearchResponse(
         fun toModel(
             dateTimeToShow: String,
             dateTimeMill: Long
-        ): ImageModel = ImageModel(
+        ): SearchImageModel = SearchImageModel(
             dateTimeToShow = dateTimeToShow,
             dateTimeMill = dateTimeMill,
             imageUrl = thumbnail,
-            thumbnailUrl = null
+            thumbnailUrl = null,
+            imageType = ImageModel.ImageType.Video
         )
     }
 

--- a/app/src/main/java/com/gallery/kakaogallery/data/repository/ImageRepositoryImpl.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/data/repository/ImageRepositoryImpl.kt
@@ -3,9 +3,7 @@ package com.gallery.kakaogallery.data.repository
 import com.gallery.kakaogallery.data.datasource.ImageSearchDataSource
 import com.gallery.kakaogallery.data.datasource.SaveImageDataSource
 import com.gallery.kakaogallery.data.datasource.VideoSearchDataSource
-import com.gallery.kakaogallery.domain.model.ImageModel
-import com.gallery.kakaogallery.domain.model.MaxPageException
-import com.gallery.kakaogallery.domain.model.UnKnownException
+import com.gallery.kakaogallery.domain.model.*
 import com.gallery.kakaogallery.domain.repository.ImageRepository
 import com.gallery.kakaogallery.domain.util.GalleryDateConvertUtil
 import io.reactivex.rxjava3.core.Completable
@@ -25,7 +23,7 @@ class ImageRepositoryImpl @Inject constructor(
     private val saveImageDataSource: SaveImageDataSource
 ) : ImageRepository {
 
-    private fun fetchImageQuery(query: String, page: Int): Single<List<ImageModel>> {
+    private fun fetchImageQuery(query: String, page: Int): Single<List<SearchImageModel>> {
         return imageSearchDataSource.fetchImageQueryRes(query, page)
             .observeOn(Schedulers.computation())
             .map {
@@ -38,7 +36,7 @@ class ImageRepositoryImpl @Inject constructor(
             }
     }
 
-    private fun fetchVideoQuery(query: String, page: Int): Single<List<ImageModel>> {
+    private fun fetchVideoQuery(query: String, page: Int): Single<List<SearchImageModel>> {
         return videoSearchDataSource.fetchVideoQueryRes(query, page)
             .observeOn(Schedulers.computation())
             .map {
@@ -54,7 +52,7 @@ class ImageRepositoryImpl @Inject constructor(
     // zip 은 가장 최근에 zip 되지 않은 데이터들끼리 zip 을 한다
     // 두개의 api 중 하나만 성공하고, 하나만 실패하는경우 다음 검색의 결과값에 이전 결과값의 데이터가 남아서 영향을 주게 되므로 api 에러가 뜨는 경우 빈 데이터를 넣어서 onNext 해준다
     // BiFunction 의 작업 환경은 첫번째 Stream 스케쥴러를 따라간다
-    override fun fetchQueryData(query: String, page: Int): Single<List<ImageModel>> {
+    override fun fetchQueryData(query: String, page: Int): Single<List<SearchImageModel>> {
         return Single.zip(
             fetchImageQuery(query, page)
                 .observeOn(Schedulers.computation())
@@ -84,16 +82,23 @@ class ImageRepositoryImpl @Inject constructor(
             }
     }
 
-    private fun Single<List<ImageModel>>.wrapResult(): Single<Result<List<ImageModel>>> =
+    private fun Single<List<SearchImageModel>>.wrapResult(): Single<Result<List<SearchImageModel>>> =
         this.map {
             Result.success(it)
         }.onErrorReturn {
             Result.failure(it)
         }
 
-    override fun fetchSaveImages(): Observable<List<ImageModel>> {
+    override fun fetchSaveImages(): Observable<List<GalleryImageModel>> {
         return saveImageDataSource.fetchSaveImages()
             .subscribeOn(Schedulers.io())
+            .map {
+                it.map {  data ->
+                    data.toModel(
+                        dateTimeToShow = GalleryDateConvertUtil.convertToPrint(data.saveDateTimeMill) ?: "",
+                    )
+                }
+            }
     }
 
     override fun removeImages(idxList: List<Int>): Completable {
@@ -101,8 +106,8 @@ class ImageRepositoryImpl @Inject constructor(
             .subscribeOn(Schedulers.io())
     }
 
-    override fun saveImages(image: List<ImageModel>): Completable {
-        return saveImageDataSource.saveImages(image)
+    override fun saveImages(image: List<SearchImageModel>, saveDateTimeMill: Long): Completable {
+        return saveImageDataSource.saveImages(image, saveDateTimeMill)
             .subscribeOn(Schedulers.io())
     }
 

--- a/app/src/main/java/com/gallery/kakaogallery/domain/model/GalleryImageModel.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/domain/model/GalleryImageModel.kt
@@ -1,0 +1,36 @@
+package com.gallery.kakaogallery.domain.model
+
+import java.io.Serializable
+
+data class GalleryImageModel(
+    override val dateTimeToShow: String,
+    override val imageUrl: String,
+    override val thumbnailUrl: String?,
+    override val imageType: ImageType,
+    override var isSelect: Boolean = false
+) : ImageModel(), Serializable {
+    companion object {
+        val Empty: GalleryImageModel
+            get() = GalleryImageModel("", "", null, ImageType.Image)
+    }
+    override val hash: String = imageUrl + dateTimeToShow
+
+    override val imageThumbUrl: String
+        get() = thumbnailUrl ?: imageUrl
+    override val isImageType: Boolean
+        get() = imageType == ImageType.Image
+
+    infix fun isSameItem(other: Any?): Boolean {
+        return when (other) {
+            is GalleryImageModel -> this.hash == other.hash
+            else -> false
+        }
+    }
+
+    infix fun isSameContent(other: Any?): Boolean {
+        return when (other) {
+            is GalleryImageModel -> this == other
+            else -> false
+        }
+    }
+}

--- a/app/src/main/java/com/gallery/kakaogallery/domain/model/ImageListTypeModel.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/domain/model/ImageListTypeModel.kt
@@ -4,7 +4,7 @@ import java.io.Serializable
 
 sealed class ImageListTypeModel : Serializable {
     data class Query(val query: String?): ImageListTypeModel()
-    data class Image(val image: ImageModel): ImageListTypeModel()
+    data class Image(val image: SearchImageModel): ImageListTypeModel()
 
     enum class ViewType(val id: Int) {
         Query(0),

--- a/app/src/main/java/com/gallery/kakaogallery/domain/model/ImageModel.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/domain/model/ImageModel.kt
@@ -1,50 +1,23 @@
 package com.gallery.kakaogallery.domain.model
 
-import java.io.Serializable
-import java.text.SimpleDateFormat
-import java.util.*
+abstract class ImageModel {
 
-/*
-    1. dateTime => 출력 가능한 형태로 저장
-    2. dateTimeMill => 비교할일 없음 => x
-    3. saveTime => String? => 출력 가능한 형태로 저장
-    4. saveTimeMill => 저장할때만 필요 -> 가지고있자
-
-    => isSave -> saveTime 이 있는지 없는지로 체크하자
-
-    url : String
-    thumbnail url : String
-
- */
-data class ImageModel internal constructor(
-    val dateTimeToShow: String,
-    val dateTimeMill: Long?,
-    val imageUrl: String,
-    private val thumbnailUrl: String?,
-    var saveDateTimeToShow: String? = null,
-    var saveTimeMill: Long? = null,
-    var isSelect: Boolean = false
-) : Serializable {
-    companion object {
-        val Empty: ImageModel = ImageModel("", 0, "", null)
+    enum class ImageType {
+        Image, Video
     }
 
-    val hash: String = imageUrl + if(saveDateTimeToShow.isNullOrBlank()) dateTimeToShow else saveDateTimeToShow
+    abstract val dateTimeToShow: String
+    abstract val imageUrl: String
+    protected abstract val thumbnailUrl: String?
+    abstract val imageType: ImageType
+    open var isSelect: Boolean = false
 
-    val isImageType: Boolean
-        get() = thumbnailUrl.isNullOrBlank()
-    val imageThumbUrl: String
-        get() = thumbnailUrl ?: imageUrl
-    val isSaveImage: Boolean
-        get() = saveDateTimeToShow != null && saveTimeMill != null
-
-    fun setRemovedImage() {
-        saveDateTimeToShow = null
-        saveTimeMill = null
-    }
+    abstract val hash: String
+    abstract val isImageType: Boolean
+    abstract val imageThumbUrl: String
 
     fun toMinString(): String {
-        return "dateTime : $dateTimeToShow, isSaveImage : ${isSaveImage}, imageUrl : $imageUrl\nisSelect : $isSelect, saveDateTime : $saveDateTimeToShow, saveTimeMill : $saveTimeMill"
+        return "dateTime : $dateTimeToShow, imageUrl : $imageUrl\nisSelect : $isSelect"
     }
     
 }

--- a/app/src/main/java/com/gallery/kakaogallery/domain/model/SearchImageModel.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/domain/model/SearchImageModel.kt
@@ -1,0 +1,25 @@
+package com.gallery.kakaogallery.domain.model
+
+import java.io.Serializable
+
+data class SearchImageModel(
+    override val dateTimeToShow: String,
+    val dateTimeMill: Long,
+    override val imageUrl: String,
+    override val thumbnailUrl: String?,
+    override val imageType: ImageType,
+    override var isSelect: Boolean = false
+) : ImageModel(), Serializable {
+    companion object {
+        val Empty: SearchImageModel
+            get() = SearchImageModel("", 0L, "", null, ImageType.Image)
+    }
+    override val hash: String = imageUrl + dateTimeToShow
+
+    override val imageThumbUrl: String
+        get() = thumbnailUrl ?: imageUrl
+    override val isImageType: Boolean
+        get() = imageType == ImageType.Image
+}
+
+

--- a/app/src/main/java/com/gallery/kakaogallery/domain/repository/ImageRepository.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/domain/repository/ImageRepository.kt
@@ -1,16 +1,18 @@
 package com.gallery.kakaogallery.domain.repository
 
+import com.gallery.kakaogallery.domain.model.GalleryImageModel
 import com.gallery.kakaogallery.domain.model.ImageModel
+import com.gallery.kakaogallery.domain.model.SearchImageModel
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.core.Single
 
 interface ImageRepository {
-    fun fetchQueryData(query: String, page: Int): Single<List<ImageModel>>
+    fun fetchQueryData(query: String, page: Int): Single<List<SearchImageModel>>
 
-    fun fetchSaveImages(): Observable<List<ImageModel>>
+    fun fetchSaveImages(): Observable<List<GalleryImageModel>>
 
     fun removeImages(idxList: List<Int>): Completable
 
-    fun saveImages(image: List<ImageModel>): Completable
+    fun saveImages(image: List<SearchImageModel>, saveDateTimeMill: Long): Completable
 }

--- a/app/src/main/java/com/gallery/kakaogallery/domain/usecase/FetchSaveImageUseCase.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/domain/usecase/FetchSaveImageUseCase.kt
@@ -1,5 +1,6 @@
 package com.gallery.kakaogallery.domain.usecase
 
+import com.gallery.kakaogallery.domain.model.GalleryImageModel
 import com.gallery.kakaogallery.domain.model.ImageModel
 import com.gallery.kakaogallery.domain.repository.ImageRepository
 import io.reactivex.rxjava3.core.Observable
@@ -8,7 +9,7 @@ import io.reactivex.rxjava3.schedulers.Schedulers
 class FetchSaveImageUseCase(
     private val imageRepository: ImageRepository
 ) {
-    operator fun invoke(): Observable<Result<List<ImageModel>>> {
+    operator fun invoke(): Observable<Result<List<GalleryImageModel>>> {
         return imageRepository
             .fetchSaveImages()
             .observeOn(Schedulers.computation())

--- a/app/src/main/java/com/gallery/kakaogallery/domain/usecase/SaveSelectImageUseCase.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/domain/usecase/SaveSelectImageUseCase.kt
@@ -2,6 +2,7 @@ package com.gallery.kakaogallery.domain.usecase
 
 import com.gallery.kakaogallery.domain.model.ImageListTypeModel
 import com.gallery.kakaogallery.domain.model.ImageModel
+import com.gallery.kakaogallery.domain.model.SearchImageModel
 import com.gallery.kakaogallery.domain.repository.ImageRepository
 import com.gallery.kakaogallery.domain.util.GalleryDateConvertUtil
 import io.reactivex.rxjava3.core.Completable
@@ -14,20 +15,17 @@ class SaveSelectImageUseCase(
 ) {
     operator fun invoke(selectImageUrlMap: MutableMap<String, Int>, images: List<ImageListTypeModel>): Single<Boolean>{
         return Completable.defer{
-            val saveImages = mutableListOf<ImageModel>()
+            val saveImages = mutableListOf<SearchImageModel>()
             for(selectIdx in selectImageUrlMap.values){
-                val saveTimeMill = Date().time
                 saveImages.add(
                     (images[selectIdx] as ImageListTypeModel.Image).let {
                         it.copy(image = it.image.copy(
-                            saveTimeMill = saveTimeMill,
-                            saveDateTimeToShow = GalleryDateConvertUtil.convertToPrint(saveTimeMill),
                             isSelect = false
                         ))
                     }.image
                 )
             }
-            imageRepository.saveImages(saveImages)
+            imageRepository.saveImages(saveImages, Date().time)
         }.subscribeOn(Schedulers.computation())
             .toSingle {
                 true

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/ui/gallery/GalleryAdapter.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/ui/gallery/GalleryAdapter.kt
@@ -3,10 +3,9 @@ package com.gallery.kakaogallery.presentation.ui.gallery
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
-import com.gallery.kakaogallery.domain.model.ImageListTypeModel
+import com.gallery.kakaogallery.domain.model.GalleryImageModel
 import com.gallery.kakaogallery.domain.model.ImageModel
 import com.gallery.kakaogallery.presentation.ui.searchimage.GalleryImageItemViewHolder
-import com.gallery.kakaogallery.presentation.ui.searchimage.ImageDiffUtilCallback
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.Disposable
@@ -18,32 +17,29 @@ class GalleryAdapter(
 ) : RecyclerView.Adapter<GalleryImageItemViewHolder>() {
 
     enum class Payload {
-        Save,
         Select
     }
 
-    private var imageList: List<ImageModel> = emptyList()
+    private var imageList: List<GalleryImageModel> = emptyList()
     val currentItemSize: Int
         get() = imageList.size
 
-    fun setList(list: List<ImageModel>) {
+    fun setList(list: List<GalleryImageModel>) {
         imageList = list
     }
 
-    private fun getDiffRes(newList: List<ImageModel>): DiffUtil.DiffResult {
+    private fun getDiffRes(newList: List<GalleryImageModel>): DiffUtil.DiffResult {
         Timber.d("getDiffRes run at ${Thread.currentThread().name}")
-        val diffCallback = ImageDiffUtilCallback(
-            this.imageList.map { ImageListTypeModel.Image(it) },
-            newList.map { ImageListTypeModel.Image(it) },
-            null,
-            Payload.Select,
-            Payload.Save
+        val diffCallback = GalleryImageDiffUtilCallback(
+            this.imageList,
+            newList,
+            Payload.Select
         )
         return DiffUtil.calculateDiff(diffCallback)
     }
 
     private var adapterDisposable: Disposable? = null
-    fun updateList(list: List<ImageModel>) {
+    fun updateList(list: List<GalleryImageModel>) {
         adapterDisposable?.dispose()
         adapterDisposable = null
 
@@ -73,7 +69,7 @@ class GalleryAdapter(
     }
 
     override fun onBindViewHolder(holder: GalleryImageItemViewHolder, position: Int) {
-        holder.bind(imageList[position])
+        holder.bind(imageList[position], true)
     }
 
     override fun onBindViewHolder(
@@ -87,11 +83,6 @@ class GalleryAdapter(
         }
         for (payload in payloads) {
             when (payload) {
-                Payload.Save -> {
-                    Timber.d("payload Save : $position => $position")
-                    holder.bindIsSave(imageList[position])
-                    holder.bindIsSelect(imageList[position])
-                }
                 Payload.Select -> {
                     Timber.d("payload Select : $position => $position")
                     holder.bindIsSelect(imageList[position])

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/ui/gallery/GalleryImageDiffUtilCallback.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/ui/gallery/GalleryImageDiffUtilCallback.kt
@@ -1,0 +1,33 @@
+package com.gallery.kakaogallery.presentation.ui.gallery
+
+import androidx.recyclerview.widget.DiffUtil
+import com.gallery.kakaogallery.domain.model.GalleryImageModel
+import timber.log.Timber
+
+class GalleryImageDiffUtilCallback(
+    private val oldList: List<GalleryImageModel>,
+    private val newList: List<GalleryImageModel>,
+    private val selectPayload: Any?
+) : DiffUtil.Callback() {
+    override fun getOldListSize(): Int = oldList.size
+
+    override fun getNewListSize(): Int = newList.size
+
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        return oldList[oldItemPosition] isSameItem newList[newItemPosition]
+    }
+
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        return oldList[oldItemPosition] isSameContent newList[newItemPosition]
+    }
+
+    override fun getChangePayload(oldItemPosition: Int, newItemPosition: Int): Any? {
+        val old = oldList[oldItemPosition]
+        val new = newList[newItemPosition]
+        Timber.d("getChangePayload called")
+        return when {
+            old.isSelect != new.isSelect -> selectPayload
+            else -> super.getChangePayload(oldItemPosition, newItemPosition)
+        }
+    }
+}

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/ui/searchimage/GalleryImageItemViewHolder.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/ui/searchimage/GalleryImageItemViewHolder.kt
@@ -22,21 +22,21 @@ class GalleryImageItemViewHolder private constructor(
     }
 
     val itemPosition: Int
-        get() = adapterPosition
+        get() = bindingAdapterPosition
 
-    fun bind(item: ImageModel) {
+    fun bind(item: ImageModel, isSave: Boolean) {
         binding.holder = this
         binding.imageItem = item
         bindIsSelect(item)
-        bindIsSave(item)
+        bindIsSave(isSave)
     }
 
     fun bindIsSelect(item: ImageModel) {
         binding.isSelectImage = item.isSelect
     }
 
-    fun bindIsSave(item: ImageModel) {
-        binding.isSaveImage = item.isSaveImage
+    private fun bindIsSave(isSave: Boolean) {
+        binding.isSaveImage = isSave
     }
 
 }

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/ui/searchimage/ImageDiffUtilCallback.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/ui/searchimage/ImageDiffUtilCallback.kt
@@ -16,8 +16,7 @@ class ImageDiffUtilCallback(
     private val oldList: List<ImageListTypeModel>,
     private val newList: List<ImageListTypeModel>,
     private val queryPayload: Any?,
-    private val selectPayload: Any?,
-    private val savePayload: Any?
+    private val selectPayload: Any?
 ) : DiffUtil.Callback() {
     override fun getOldListSize(): Int = oldList.size
 
@@ -46,7 +45,6 @@ class ImageDiffUtilCallback(
             old is ImageListTypeModel.Image && new is ImageListTypeModel.Image -> {
                 when {
                     old.image.isSelect != new.image.isSelect -> selectPayload
-                    old.image.isSaveImage != new.image.isSaveImage -> savePayload
                     else -> super.getChangePayload(oldItemPosition, newItemPosition)
                 }
             }

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/ui/searchimage/SearchImageDiffUtilCallback.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/ui/searchimage/SearchImageDiffUtilCallback.kt
@@ -12,7 +12,7 @@ import timber.log.Timber
  * => old/new 두 리스트의 합인 N개 / old가 new로 변환되기 위해 필요한 최소 작업갯수(==edit script) D
  * 최대 사이즈는 2^26(67,108,864)개까지 지원
  */
-class ImageDiffUtilCallback(
+class SearchImageDiffUtilCallback(
     private val oldList: List<ImageListTypeModel>,
     private val newList: List<ImageListTypeModel>,
     private val queryPayload: Any?,

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/ui/searchimage/SearchImagesAdapter.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/ui/searchimage/SearchImagesAdapter.kt
@@ -55,7 +55,7 @@ class SearchImagesAdapter(
 
     private fun getDiffRes(newList: List<ImageListTypeModel>): DiffUtil.DiffResult {
         Timber.d("getDiffRes run at ${Thread.currentThread().name}")
-        val diffCallback = ImageDiffUtilCallback(
+        val diffCallback = SearchImageDiffUtilCallback(
             this.imageList,
             newList,
             Payload.Query,

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/ui/searchimage/SearchImagesAdapter.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/ui/searchimage/SearchImagesAdapter.kt
@@ -42,7 +42,6 @@ class SearchImagesAdapter(
 
     enum class Payload {
         Query,
-        Save,
         Select
     }
 
@@ -60,8 +59,7 @@ class SearchImagesAdapter(
             this.imageList,
             newList,
             Payload.Query,
-            Payload.Select,
-            Payload.Save
+            Payload.Select
         )
         return DiffUtil.calculateDiff(diffCallback)
     }
@@ -103,7 +101,7 @@ class SearchImagesAdapter(
             is SearchQueryViewHolder ->
                 holder.bind((imageList[position] as ImageListTypeModel.Query))
             is GalleryImageItemViewHolder ->
-                holder.bind((imageList[position] as ImageListTypeModel.Image).image)
+                holder.bind((imageList[position] as ImageListTypeModel.Image).image, false)
         }
     }
 
@@ -118,13 +116,6 @@ class SearchImagesAdapter(
         }
         for (payload in payloads) {
             when (payload) {
-                Payload.Save -> {
-                    if (holder is GalleryImageItemViewHolder) {
-                        Timber.d("payload Save : $position => $position")
-                        holder.bindIsSave((imageList[position] as ImageListTypeModel.Image).image)
-                        holder.bindIsSelect((imageList[position] as ImageListTypeModel.Image).image)
-                    }
-                }
                 Payload.Select -> {
                     if (holder is GalleryImageItemViewHolder) {
                         Timber.d("payload Select : $position => $position")

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/GalleryViewModel.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/GalleryViewModel.kt
@@ -3,6 +3,7 @@ package com.gallery.kakaogallery.presentation.viewmodel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import com.gallery.kakaogallery.domain.model.GalleryImageModel
 import com.gallery.kakaogallery.domain.model.ImageModel
 import com.gallery.kakaogallery.domain.model.MaxPageException
 import com.gallery.kakaogallery.domain.usecase.FetchSaveImageUseCase
@@ -35,8 +36,8 @@ class GalleryViewModel @Inject constructor(
         mutableMapOf<String, Int>().also { handle[KEY_SELECT_IMAGE_MAP] = it }
     }
 
-    private val _saveImages: MutableLiveData<List<ImageModel>> = handle.getLiveData(KEY_SAVE_IMAGE_LIST, emptyList())
-    val saveImages: LiveData<List<ImageModel>> = _saveImages
+    private val _saveImages: MutableLiveData<List<GalleryImageModel>> = handle.getLiveData(KEY_SAVE_IMAGE_LIST, emptyList())
+    val saveImages: LiveData<List<GalleryImageModel>> = _saveImages
 
     private val _headerTitle: MutableLiveData<String> =
         handle.getLiveData(KEY_HEADER_TITLE, resourceProvider.getString(StringResourceProvider.StringResourceId.MenuGallery))

--- a/app/src/main/res/layout/item_gallery_image.xml
+++ b/app/src/main/res/layout/item_gallery_image.xml
@@ -2,6 +2,7 @@
 <layout>
     <data>
         <import type="android.view.View"/>
+        <import type="com.gallery.kakaogallery.domain.model.ImageModel.ImageType"/>
 
         <variable
             name="holder"
@@ -69,7 +70,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="5dp"
                     android:layout_marginTop="5dp"
-                    android:src="@{imageItem.imageType ? @drawable/ic_image : @drawable/ic_video}"
+                    android:src="@{imageItem.imageType == ImageType.Image ? @drawable/ic_image : @drawable/ic_video}"
                     />
             </RelativeLayout>
 
@@ -79,7 +80,7 @@
                 android:orientation="vertical">
 
                 <TextView
-                    android:text="@{isSaveImage ? imageItem.saveDateTimeToShow : imageItem.dateTimeToShow}"
+                    android:text="@{imageItem.dateTimeToShow}"
                     android:id="@+id/tv_date_time"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content" />

--- a/app/src/test/java/com/gallery/kakaogallery/data/datasource/SaveImageDataSourceImplTest.kt
+++ b/app/src/test/java/com/gallery/kakaogallery/data/datasource/SaveImageDataSourceImplTest.kt
@@ -1,10 +1,13 @@
 package com.gallery.kakaogallery.data.datasource
 
 import com.gallery.kakaogallery.data.dao.SaveImageDao
+import com.gallery.kakaogallery.data.entity.local.ImageEntity
 import com.gallery.kakaogallery.domain.model.ImageModel
+import com.gallery.kakaogallery.domain.model.SearchImageModel
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Test
+import java.util.*
 
 @Suppress("NonAsciiCharacters")
 internal class SaveImageDataSourceImplTest {
@@ -36,11 +39,12 @@ internal class SaveImageDataSourceImplTest {
     @Test
     fun `saveImages는 SaveImageDao의 saveImages를 호출한다`() {
         val saveImageDao: SaveImageDao = mockk(relaxed = true)
-        val list = emptyList<ImageModel>()
+        val saveMill = Date().time
+        val searchImages = emptyList<SearchImageModel>()
         saveImageDataSource = SaveImageDataSourceImpl(saveImageDao)
-        saveImageDataSource.saveImages(list).blockingAwait()
+        saveImageDataSource.saveImages(searchImages, saveMill).blockingAwait()
 
-        verify { saveImageDao.saveImages(list) }
+        verify { saveImageDao.saveImages(searchImages, saveMill) }
     }
 
 }

--- a/app/src/test/java/com/gallery/kakaogallery/domain/usecase/FetchQueryDataUseCaseTest.kt
+++ b/app/src/test/java/com/gallery/kakaogallery/domain/usecase/FetchQueryDataUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.gallery.kakaogallery.domain.usecase
 
 import com.gallery.kakaogallery.domain.model.ImageListTypeModel
 import com.gallery.kakaogallery.domain.model.ImageModel
+import com.gallery.kakaogallery.domain.model.SearchImageModel
 import com.gallery.kakaogallery.domain.repository.ImageRepository
 import io.mockk.every
 import io.mockk.mockk
@@ -55,8 +56,8 @@ internal class FetchQueryDataUseCaseTest {
     fun `useCase는 page가 1이면 Query를 첫번째 아이템으로 가지는 ImageListType리스트를 리턴한다`() {
         val (query, page) = "query" to 1
         val images = listOf(
-            ImageModel.Empty,
-            ImageModel.Empty.copy(imageUrl = "123")
+            SearchImageModel.Empty,
+            SearchImageModel.Empty.copy(imageUrl = "123")
         )
 
         every { repository.fetchQueryData(query, page) } returns Single.just(images)
@@ -78,8 +79,8 @@ internal class FetchQueryDataUseCaseTest {
     fun `useCase는 page가 1이 아니라면 Image만을 포함하는 리스트를 리턴한다`() {
         val (query, page) = "query" to 2
         val images = listOf(
-            ImageModel.Empty,
-            ImageModel.Empty.copy(imageUrl = "123")
+            SearchImageModel.Empty,
+            SearchImageModel.Empty.copy(imageUrl = "123")
         )
 
         every { repository.fetchQueryData(query, page) } returns Single.just(images)

--- a/app/src/test/java/com/gallery/kakaogallery/domain/usecase/FetchSaveImageUseCaseTest.kt
+++ b/app/src/test/java/com/gallery/kakaogallery/domain/usecase/FetchSaveImageUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.gallery.kakaogallery.domain.usecase
 
+import com.gallery.kakaogallery.domain.model.GalleryImageModel
 import com.gallery.kakaogallery.domain.model.ImageModel
 import com.gallery.kakaogallery.domain.repository.ImageRepository
 import io.mockk.every
@@ -43,8 +44,8 @@ internal class FetchSaveImageUseCaseTest {
     @Test
     fun `useCase는 repository가 정상 응답시 결과를 Result로 래핑`() {
         val images = listOf(
-            ImageModel.Empty,
-            ImageModel.Empty.copy(imageUrl = "test123")
+            GalleryImageModel.Empty,
+            GalleryImageModel.Empty.copy(imageUrl = "test123")
         )
         every { repository.fetchSaveImages() } returns Observable.just(images)
 

--- a/app/src/test/java/com/gallery/kakaogallery/domain/usecase/SaveSelectImageUseCaseTest.kt
+++ b/app/src/test/java/com/gallery/kakaogallery/domain/usecase/SaveSelectImageUseCaseTest.kt
@@ -30,7 +30,7 @@ internal class SaveSelectImageUseCaseTest {
     //state test
     fun `useCase는 repository가 에러를 전달하면 처리할 수 있다`() {
         val unitTestException = Exception("unit test exception")
-        every { repository.saveImages(any()) } returns Completable.error(unitTestException)
+        every { repository.saveImages(any(), any()) } returns Completable.error(unitTestException)
         val actual = catchThrowable { useCase(mutableMapOf(), emptyList()).blockingGet() }
         assertThat(actual)
             .isInstanceOf(Exception::class.java)
@@ -40,7 +40,7 @@ internal class SaveSelectImageUseCaseTest {
     @Test
     //state test
     fun `useCase는 repository가 정상 응답시 true를 리턴한다`() {
-        every { repository.saveImages(any()) } returns Completable.complete()
+        every { repository.saveImages(any(), any()) } returns Completable.complete()
         val actual = useCase(mutableMapOf(), emptyList()).blockingGet()
         assertThat(actual)
             .isTrue
@@ -61,8 +61,8 @@ internal class SaveSelectImageUseCaseTest {
     //behavior test
     @Test
     fun `useCase는 repository의 saveImages를 호출한다`() {
-        every { repository.saveImages(any()) } returns Completable.complete()
+        every { repository.saveImages(any(), any()) } returns Completable.complete()
         useCase(mutableMapOf(), emptyList()).blockingGet()
-        verify { repository.saveImages(any()) }
+        verify { repository.saveImages(any(), any()) }
     }
 }


### PR DESCRIPTION
## 📪  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #61 
## 📚  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] 이미지 저장시에 Model, Entity 구분
    -  local에 저장되는 데이터는 최대한 다양한raw data를 저장
    - 비즈니스 로직에 사용될 model은 필요한 최소한의 데이터만을 보유
- [x] Adapter, ViewHolder를 재사용 가능하도록 ImageModel을 추상화
- [x] 관련 테스트 케이스 작성, 수정, 검증

closed #61 