### PR TITLE
[Fix] 이미지 선택 도중 다른 query검색 시, 이전 이미지 선택 정보가 남아있는 문제

### DIFF
--- a/app/src/main/java/com/gallery/kakaogallery/presentation/ui/searchimage/SearchImageFragment.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/ui/searchimage/SearchImageFragment.kt
@@ -39,7 +39,7 @@ class SearchImageFragment : BindingFragment<FragmentSearchImageBinding>(),
 
     private val imageSearchAdapter: SearchImagesAdapter by lazy {
         SearchImagesAdapter(
-            viewModel::searchQuery,
+            viewModel::searchQueryEvent,
             searchEditorActionListener,
             viewModel::touchImageEvent
         )
@@ -52,7 +52,7 @@ class SearchImageFragment : BindingFragment<FragmentSearchImageBinding>(),
         override fun onEditorAction(v: TextView?, actionId: Int, event: KeyEvent?): Boolean {
             when (actionId) {
                 EditorInfo.IME_ACTION_SEARCH -> {
-                    viewModel.searchQuery(v?.text.toString())
+                    viewModel.searchQueryEvent(v?.text.toString())
                     return true
                 }
             }

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/SearchImageViewModel.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/SearchImageViewModel.kt
@@ -167,17 +167,22 @@ class SearchImageViewModel @Inject constructor(
 
     fun clickSelectModeEvent() {
         when (_selectMode.value) {
-            true -> {
-                unSelectAllImage()
-                _headerTitle.value =
-                    resourceProvider.getString(StringResourceProvider.StringResourceId.MenuSearchImage)
-            }
+            true -> unSelectAllImage()
+            else -> {}
+        }
+        setHeaderTitleUseSelectMap()
+        _selectMode.value = !(_selectMode.value ?: false)
+    }
+
+    private fun setHeaderTitleUseSelectMap() {
+        when (selectImageUrlMap.isEmpty()) {
+            true -> _headerTitle.value =
+                resourceProvider.getString(StringResourceProvider.StringResourceId.MenuSearchImage)
             else -> _headerTitle.value = resourceProvider.getString(
                 StringResourceProvider.StringResourceId.SelectState,
                 selectImageUrlMap.size
             )
         }
-        _selectMode.value = !(_selectMode.value ?: false)
     }
 
     private fun unSelectAllImage() {
@@ -206,10 +211,7 @@ class SearchImageViewModel @Inject constructor(
                 else -> selectImageUrlMap.remove(image.imageUrl)
             }
             _searchImages.value = images
-            _headerTitle.value = resourceProvider.getString(
-                StringResourceProvider.StringResourceId.SelectState,
-                selectImageUrlMap.size
-            )
+            setHeaderTitleUseSelectMap()
         } catch (e: Exception) {
             e.printStackTrace()
             showToast(resourceProvider.getString(StringResourceProvider.StringResourceId.SelectFail))

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/SearchImageViewModel.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/SearchImageViewModel.kt
@@ -140,7 +140,7 @@ class SearchImageViewModel @Inject constructor(
                 val prevList = _searchImages.value ?: emptyList()
                 _searchImages.value = prevList + it
             }) {
-                _dataLoading.value = false
+                _pagingDataLoading.value = false
                 when (it) {
                     is MaxPageException -> showToast(
                         resourceProvider.getString(

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/SearchImageViewModel.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/SearchImageViewModel.kt
@@ -226,7 +226,7 @@ class SearchImageViewModel @Inject constructor(
         }
     }
 
-    fun searchQuery(query: String) {
+    fun searchQueryEvent(query: String) {
         Timber.d("search query : $query")
         _uiEvent.value = SingleEvent(UiEvent.KeyboardVisibleEvent(false))
         if (query.isBlank()) {

--- a/buildSrc/src/main/java/AppConfig.kt
+++ b/buildSrc/src/main/java/AppConfig.kt
@@ -3,7 +3,7 @@ object AppConfig {
     const val applicationId = "com.gallery.kakaogallery"
 
     const val compileSdk = 33
-    const val minSdk = 23
+    const val minSdk = 24
     const val targetSdk = 33
 
     const val versionCode = 1


### PR DESCRIPTION
## 📪  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #77 
## 📚  What's-New
<!-- 한 일들을 적어주세요. -->
- [x]  새로운 query를 검색한다면, 기존 선택된 이미지 초기화
- [x]  같은 query를 검색한다면, 기존 선택된 이미지 유지
- [x]  같은 query를 검색할때, 1페이지가 아닌 페이지에 선택된 이미지가 존재한다면, 해당 선택된 이미지는 초기화 처리

closed #77 
