### PR TITLE
[Feature] 이미지 자세히 보기 화면 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.KakaoGallery">
         <activity
+            android:theme="@style/Theme.ImageDetail"
             android:name=".presentation.ui.imagedetail.ImageDetailActivity"
             android:exported="false">
         </activity>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,9 +17,6 @@
         <activity
             android:name=".presentation.ui.imagedetail.ImageDetailActivity"
             android:exported="false">
-            <meta-data
-                android:name="android.app.lib_name"
-                android:value="" />
         </activity>
         <activity
             android:name=".presentation.ui.root.RootActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
+        android:usesCleartextTraffic="true"
         android:name=".presentation.application.KakaoGalleryApplication"
         android:allowBackup="true"
         android:icon="@mipmap/app_icon"
@@ -14,9 +15,16 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.KakaoGallery">
         <activity
-            android:theme="@style/Theme.KakaoGallery.Splash"
+            android:name=".presentation.ui.imagedetail.ImageDetailActivity"
+            android:exported="false">
+            <meta-data
+                android:name="android.app.lib_name"
+                android:value="" />
+        </activity>
+        <activity
             android:name=".presentation.ui.root.RootActivity"
-            android:exported="true">
+            android:exported="true"
+            android:theme="@style/Theme.KakaoGallery.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/gallery/kakaogallery/domain/model/GalleryImageListTypeModel.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/domain/model/GalleryImageListTypeModel.kt
@@ -1,6 +1,8 @@
 package com.gallery.kakaogallery.domain.model
 
-sealed class GalleryImageListTypeModel {
+import java.io.Serializable
+
+sealed class GalleryImageListTypeModel : Serializable {
     data class Image(val image: GalleryImageModel): GalleryImageListTypeModel()
     object Skeleton : GalleryImageListTypeModel()
 

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/ui/base/BindingActivity.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/ui/base/BindingActivity.kt
@@ -12,5 +12,6 @@ abstract class BindingActivity<T : ViewDataBinding> : LifeCycleLoggingActivity()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = DataBindingUtil.setContentView(this, layoutResId)
+        binding.lifecycleOwner = this
     }
 }

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/ui/bindingadapter/ImageViewBindingAdapter.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/ui/bindingadapter/ImageViewBindingAdapter.kt
@@ -6,6 +6,7 @@ import androidx.databinding.BindingAdapter
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.load.resource.gif.GifDrawable
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.Target
 import com.gallery.kakaogallery.R
@@ -26,7 +27,7 @@ fun loadUrl(imageView: ImageView, url: String) {
  * loadInfo.second => loadFromCache
  */
 @BindingAdapter("app:loadUrl", "app:loadOnlyCache", "app:loadUrlFinishListener")
-fun loadUrlWithListener(imageView: ImageView, imageUrl: String, loadOnlyCache: Boolean, onLoadingFinish: (Boolean) -> Unit) {
+fun loadForSharedElementTransition(imageView: ImageView, imageUrl: String, loadOnlyCache: Boolean, onLoadingFinish: (success: Boolean) -> Unit) {
     Timber.d("animation debug => loadUrlWithListener\nurl[$imageUrl], loadOnlyCache[$loadOnlyCache]")
     Glide.with(imageView)
         .load(imageUrl)
@@ -54,6 +55,8 @@ fun loadUrlWithListener(imageView: ImageView, imageUrl: String, loadOnlyCache: B
                 isFirstResource: Boolean
             ): Boolean {
                 onLoadingFinish(true)
+                if(imageUrl.endsWith(".gif") || resource is GifDrawable)
+                    imageView.post { resource?.setVisible(true, true) } // shared element transition 이후에 gif 가 실행이 안되는 문제를 해결하기 위해 재실행 코드 추가
                 return false
             }
         })

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/ui/bindingadapter/ImageViewBindingAdapter.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/ui/bindingadapter/ImageViewBindingAdapter.kt
@@ -1,9 +1,15 @@
 package com.gallery.kakaogallery.presentation.ui.bindingadapter
 
+import android.graphics.drawable.Drawable
 import android.widget.ImageView
 import androidx.databinding.BindingAdapter
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.request.RequestListener
+import com.bumptech.glide.request.target.Target
 import com.gallery.kakaogallery.R
+import timber.log.Timber
 
 @BindingAdapter("app:loadUrl")
 fun loadUrl(imageView: ImageView, url: String) {
@@ -12,5 +18,44 @@ fun loadUrl(imageView: ImageView, url: String) {
         .error(R.drawable.bg_image_error)
         .placeholder(R.drawable.bg_image_placeholder)
         .override(imageView.layoutParams.width, imageView.layoutParams.height)
+        .into(imageView)
+}
+
+/**
+ * loadInfo.first => url
+ * loadInfo.second => loadFromCache
+ */
+@BindingAdapter("app:loadUrl", "app:loadOnlyCache", "app:loadUrlFinishListener")
+fun loadUrlWithListener(imageView: ImageView, imageUrl: String, loadOnlyCache: Boolean, onLoadingFinish: (Boolean) -> Unit) {
+    Timber.d("animation debug => loadUrlWithListener\nurl[$imageUrl], loadOnlyCache[$loadOnlyCache]")
+    Glide.with(imageView)
+        .load(imageUrl)
+        .error(if(loadOnlyCache) R.drawable.bg_image_placeholder else R.drawable.bg_image_error)
+        .dontTransform()
+        .onlyRetrieveFromCache(loadOnlyCache)
+        .placeholder(R.drawable.bg_image_placeholder)
+        .override(imageView.layoutParams.width, imageView.layoutParams.height)
+        .listener(object : RequestListener<Drawable> {
+            override fun onLoadFailed(
+                e: GlideException?,
+                model: Any?,
+                target: Target<Drawable>?,
+                isFirstResource: Boolean
+            ): Boolean {
+                onLoadingFinish(false)
+                return false
+            }
+
+            override fun onResourceReady(
+                resource: Drawable?,
+                model: Any?,
+                target: Target<Drawable>?,
+                dataSource: DataSource?,
+                isFirstResource: Boolean
+            ): Boolean {
+                onLoadingFinish(true)
+                return false
+            }
+        })
         .into(imageView)
 }

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/ui/gallery/GalleryFragment.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/ui/gallery/GalleryFragment.kt
@@ -1,5 +1,7 @@
 package com.gallery.kakaogallery.presentation.ui.gallery
 
+import android.app.ActivityOptions
+import android.content.Intent
 import android.content.res.Configuration
 import android.graphics.Rect
 import android.os.Bundle
@@ -18,6 +20,7 @@ import com.gallery.kakaogallery.presentation.extension.showToast
 import com.gallery.kakaogallery.presentation.ui.base.BindingFragment
 import com.gallery.kakaogallery.presentation.ui.dialog.ImageManageBottomSheetDialog
 import com.gallery.kakaogallery.presentation.ui.dialog.ImageManageBottomSheetEventReceiver
+import com.gallery.kakaogallery.presentation.ui.imagedetail.ImageDetailActivity
 import com.gallery.kakaogallery.presentation.ui.root.BottomMenuRoot
 import com.gallery.kakaogallery.presentation.viewmodel.GalleryViewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -123,6 +126,7 @@ class GalleryFragment : BindingFragment<FragmentGalleryBinding>(), ImageManageBo
                 when (it) {
                     is GalleryViewModel.UiEvent.ShowToast ->
                         context?.showToast(it.message)
+
                     is GalleryViewModel.UiEvent.ShowSnackBar -> {
                         when (it.action) {
                             null -> binding.background.showSnackBar(it.message)
@@ -136,12 +140,19 @@ class GalleryFragment : BindingFragment<FragmentGalleryBinding>(), ImageManageBo
                     }
                     is GalleryViewModel.UiEvent.KeyboardVisibleEvent ->
                         context?.setSoftKeyboardVisible(binding.background, it.visible)
+
                     is GalleryViewModel.UiEvent.PresentRemoveDialog ->
                         showRemoveDialog(it.selectCount)
+
                     is GalleryViewModel.UiEvent.NavigateSearchView ->
                         (requireActivity() as? BottomMenuRoot)?.navigateSearchTab()
+
                     is GalleryViewModel.UiEvent.ScrollToTop ->
                         binding.rvGallery.safeScrollToTop(it.smoothScroll)
+
+                    is GalleryViewModel.UiEvent.NavigateImageDetail -> {
+                        showImageDetailActivity(it.imageUrl, it.position)
+                    }
                 }
             }
         }
@@ -157,6 +168,19 @@ class GalleryFragment : BindingFragment<FragmentGalleryBinding>(), ImageManageBo
                 else -> finishSelectMode()
             }
         }
+    }
+
+    private fun showImageDetailActivity(imageUrl: String, viewPosition: Int) {
+        val imageView = binding.rvGallery
+            .findViewHolderForLayoutPosition(viewPosition)?.itemView?.findViewById<View>(R.id.iv_image)
+        startActivity(
+            ImageDetailActivity.get(requireContext(), imageUrl),
+            ActivityOptions.makeSceneTransitionAnimation(
+                requireActivity(),
+                imageView,
+                ImageDetailActivity.VIEW_NAME_IMAGE_DETAIL
+            ).toBundle()
+        )
     }
 
     private fun showRemoveDialog(selectCount: Int) {

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/ui/imagedetail/ImageDetailActivity.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/ui/imagedetail/ImageDetailActivity.kt
@@ -1,0 +1,94 @@
+package com.gallery.kakaogallery.presentation.ui.imagedetail
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.transition.Transition
+import android.view.MenuItem
+import androidx.activity.viewModels
+import com.gallery.kakaogallery.R
+import com.gallery.kakaogallery.databinding.ActivityImageDetailBinding
+import com.gallery.kakaogallery.presentation.ui.base.BindingActivity
+import com.gallery.kakaogallery.presentation.viewmodel.ImageDetailViewModel
+import dagger.hilt.android.AndroidEntryPoint
+
+/*
+    https://developer.android.com/develop/ui/views/animations/transitions/start-activity
+    https://www.thedroidsonroids.com/blog/how-to-use-shared-element-transition-with-glide-in-4-steps
+ */
+@AndroidEntryPoint
+class ImageDetailActivity : BindingActivity<ActivityImageDetailBinding>() {
+    companion object {
+        const val VIEW_NAME_IMAGE_DETAIL = "view:name:image:detail"
+        fun get(
+            context: Context,
+            imageUrl: String
+        ): Intent = Intent(context, ImageDetailActivity::class.java).apply {
+            putExtra(ImageDetailViewModel.EXTRA_IMAGE_DETAIL, imageUrl)
+            addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        }
+    }
+
+    override val layoutResId: Int
+        get() = R.layout.activity_image_detail
+
+    private val viewModel: ImageDetailViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setUpTransition()
+        bindView()
+        setActionBar()
+        observeData()
+    }
+
+    private fun setUpTransition() {
+        supportPostponeEnterTransition() // Postpone the entering activity transition when Activity was started with
+        binding.ivImage.transitionName = VIEW_NAME_IMAGE_DETAIL
+        window.sharedElementEnterTransition.addListener(object : Transition.TransitionListener {
+            override fun onTransitionStart(transition: Transition?) {}
+
+            override fun onTransitionEnd(transition: Transition?) {
+                window.sharedElementEnterTransition.removeListener(this)
+                viewModel.reloadIfCacheLoadFail()
+            }
+
+            override fun onTransitionCancel(transition: Transition?) {}
+            override fun onTransitionPause(transition: Transition?) {}
+            override fun onTransitionResume(transition: Transition?) {}
+        })
+    }
+
+    private fun bindView(){
+        binding.viewModel = viewModel
+    }
+
+    private fun setActionBar() {
+        setSupportActionBar(binding.toolBar)
+        supportActionBar?.apply {
+            setDisplayHomeAsUpEnabled(true)
+            setDisplayShowTitleEnabled(false)
+        }
+    }
+
+    private fun observeData() {
+        viewModel.uiEvent.observe(this) { event ->
+            event.getContentIfNotHandled()?.let {
+                when (it) {
+                    is ImageDetailViewModel.UiEvent.Dismiss -> finishAfterTransition()
+                    is ImageDetailViewModel.UiEvent.PostLoadImage -> supportStartPostponedEnterTransition()
+                }
+            }
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            android.R.id.home -> {
+                finishAfterTransition()
+                return true
+            }
+        }
+        return super.onOptionsItemSelected(item)
+    }
+}

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/ui/imagedetail/ImageDetailActivity.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/ui/imagedetail/ImageDetailActivity.kt
@@ -25,7 +25,6 @@ class ImageDetailActivity : BindingActivity<ActivityImageDetailBinding>() {
             imageUrl: String
         ): Intent = Intent(context, ImageDetailActivity::class.java).apply {
             putExtra(ImageDetailViewModel.EXTRA_IMAGE_DETAIL, imageUrl)
-            addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
         }
     }
 

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/ui/imagedetail/ImageDetailActivity.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/ui/imagedetail/ImageDetailActivity.kt
@@ -1,11 +1,17 @@
 package com.gallery.kakaogallery.presentation.ui.imagedetail
 
+import android.animation.Animator
+import android.animation.ObjectAnimator
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.transition.Transition
-import android.view.MenuItem
+import android.view.*
 import androidx.activity.viewModels
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import com.gallery.kakaogallery.R
 import com.gallery.kakaogallery.databinding.ActivityImageDetailBinding
 import com.gallery.kakaogallery.presentation.ui.base.BindingActivity
@@ -33,11 +39,15 @@ class ImageDetailActivity : BindingActivity<ActivityImageDetailBinding>() {
 
     private val viewModel: ImageDetailViewModel by viewModels()
 
+    private val fadeOut: ObjectAnimator by lazy { ObjectAnimator.ofFloat(binding.layoutAppBar, View.ALPHA, 1f, 0f) }
+    private val fadeIn: ObjectAnimator by lazy { ObjectAnimator.ofFloat(binding.layoutAppBar, View.ALPHA, 0f, 1f) }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setUpTransition()
         bindView()
         setActionBar()
+        setListener()
         observeData()
     }
 
@@ -63,10 +73,31 @@ class ImageDetailActivity : BindingActivity<ActivityImageDetailBinding>() {
     }
 
     private fun setActionBar() {
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            window.setDecorFitsSystemWindows(false)
+        }
         setSupportActionBar(binding.toolBar)
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowTitleEnabled(false)
+        }
+        setTopMarginAsStatusBar()
+    }
+
+    // https://developer.android.com/develop/ui/views/layout/edge-to-edge#handle-overlaps
+    private fun setTopMarginAsStatusBar() {
+        ViewCompat.setOnApplyWindowInsetsListener(binding.layoutAppBar) { view, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.statusBars())
+            view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                topMargin = insets.top
+            }
+            WindowInsetsCompat.CONSUMED
+        }
+    }
+
+    private fun setListener() {
+        binding.background.setOnClickListener {
+            viewModel.touchBackgroundEvent()
         }
     }
 
@@ -79,6 +110,93 @@ class ImageDetailActivity : BindingActivity<ActivityImageDetailBinding>() {
                 }
             }
         }
+
+        viewModel.fullScreenMode.observe(this) {
+            when (it) {
+                true -> setFadeOutAnimation(animationStartListener = {
+                    hideSystemBar()
+                })
+                else -> setFadeInAnimation(animationStartListener = {
+                    showSystemBar()
+                })
+            }
+        }
+    }
+
+
+    private fun showSystemBar(){
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            window.setDecorFitsSystemWindows(false)
+            window.insetsController?.show(WindowInsets.Type.systemBars())
+        } else@Suppress("DEPRECATION") {
+            window.decorView.systemUiVisibility = (
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
+                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN)
+        }
+    }
+
+    private fun hideSystemBar(){
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            window.insetsController?.let { controller ->
+                controller.hide(WindowInsets.Type.systemBars())
+                controller.systemBarsBehavior = WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            }
+        } else@Suppress("DEPRECATION") {
+            window.decorView.systemUiVisibility = (
+                View.SYSTEM_UI_FLAG_IMMERSIVE or
+                    // Set the content to appear under the system bars so that the
+                    // content doesn't resize when the system bars hide and show.
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
+                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
+                    // Hide the nav bar and status bar
+                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or
+                    View.SYSTEM_UI_FLAG_FULLSCREEN
+                )
+        }
+    }
+
+    private fun setFadeOutAnimation(duration: Long = 200, animationStartListener: (() -> Unit)? = null, animationEndListener: (() -> Unit)? = null) {
+        fadeOut.apply {
+            addListener(object : Animator.AnimatorListener {
+                override fun onAnimationStart(p0: Animator) {
+                    animationStartListener?.invoke()
+                }
+                override fun onAnimationEnd(p0: Animator) {
+                    animationEndListener?.invoke()
+                }
+                override fun onAnimationCancel(p0: Animator) {
+                    animationEndListener?.invoke()
+                }
+                override fun onAnimationRepeat(p0: Animator) {}
+            })
+            this.duration = duration
+        }
+        if(fadeIn.isRunning)
+            fadeIn.cancel()
+        fadeOut.start()
+    }
+
+    private fun setFadeInAnimation(duration: Long = 200, animationStartListener: (() -> Unit)? = null, animationEndListener: (() -> Unit)? = null) {
+        fadeIn.apply {
+            addListener(object : Animator.AnimatorListener {
+                override fun onAnimationStart(p0: Animator) {
+                    animationStartListener?.invoke()
+                }
+                override fun onAnimationEnd(p0: Animator) {
+                    animationEndListener?.invoke()
+                }
+                override fun onAnimationCancel(p0: Animator) {
+                    animationEndListener?.invoke()
+                }
+                override fun onAnimationRepeat(p0: Animator) {}
+            })
+            this.duration = duration
+        }
+        if(fadeOut.isRunning)
+            fadeOut.cancel()
+        fadeIn.start()
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/ui/searchimage/SearchImageFragment.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/ui/searchimage/SearchImageFragment.kt
@@ -197,8 +197,11 @@ class SearchImageFragment : BindingFragment<FragmentSearchImageBinding>(),
                             )
                         }
                     }
-                    is SearchImageViewModel.UiEvent.KeyboardVisibleEvent ->
+                    is SearchImageViewModel.UiEvent.KeyboardVisibleEvent -> {
                         context?.setSoftKeyboardVisible(binding.background, it.visible)
+                        if(!it.visible)
+                            (binding.rvSearch.findViewHolderForAdapterPosition(0) as? SearchQueryViewHolder)?.clearFocus()
+                    }
 
                     is SearchImageViewModel.UiEvent.PresentSaveDialog ->
                         showSaveDialog(it.selectCount)

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/ui/searchimage/SearchImageFragment.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/ui/searchimage/SearchImageFragment.kt
@@ -1,6 +1,7 @@
 package com.gallery.kakaogallery.presentation.ui.searchimage
 
 import android.annotation.SuppressLint
+import android.app.ActivityOptions
 import android.content.res.Configuration
 import android.graphics.Rect
 import android.os.Bundle
@@ -24,6 +25,7 @@ import com.gallery.kakaogallery.presentation.extension.showToast
 import com.gallery.kakaogallery.presentation.ui.base.BindingFragment
 import com.gallery.kakaogallery.presentation.ui.dialog.ImageManageBottomSheetDialog
 import com.gallery.kakaogallery.presentation.ui.dialog.ImageManageBottomSheetEventReceiver
+import com.gallery.kakaogallery.presentation.ui.imagedetail.ImageDetailActivity
 import com.gallery.kakaogallery.presentation.viewmodel.SearchImageViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
@@ -183,6 +185,7 @@ class SearchImageFragment : BindingFragment<FragmentSearchImageBinding>(),
                 when (it) {
                     is SearchImageViewModel.UiEvent.ShowToast ->
                         context?.showToast(it.message)
+
                     is SearchImageViewModel.UiEvent.ShowSnackBar -> {
                         when (it.action) {
                             null -> binding.background.showSnackBar(it.message)
@@ -196,10 +199,16 @@ class SearchImageFragment : BindingFragment<FragmentSearchImageBinding>(),
                     }
                     is SearchImageViewModel.UiEvent.KeyboardVisibleEvent ->
                         context?.setSoftKeyboardVisible(binding.background, it.visible)
+
                     is SearchImageViewModel.UiEvent.PresentSaveDialog ->
                         showSaveDialog(it.selectCount)
+
                     is SearchImageViewModel.UiEvent.ScrollToTop ->
                         binding.rvSearch.safeScrollToTop(it.smoothScroll)
+
+                    is SearchImageViewModel.UiEvent.NavigateImageDetail -> {
+                        showImageDetailActivity(it.imageUrl, it.position)
+                    }
                 }
             }
         }
@@ -217,6 +226,19 @@ class SearchImageFragment : BindingFragment<FragmentSearchImageBinding>(),
                 else -> finishSelectMode()
             }
         }
+    }
+
+    private fun showImageDetailActivity(imageUrl: String, viewPosition: Int) {
+        val imageView = binding.rvSearch
+            .findViewHolderForLayoutPosition(viewPosition)?.itemView?.findViewById<View>(R.id.iv_image)
+        startActivity(
+            ImageDetailActivity.get(requireContext(), imageUrl),
+            ActivityOptions.makeSceneTransitionAnimation(
+                requireActivity(),
+                imageView,
+                ImageDetailActivity.VIEW_NAME_IMAGE_DETAIL
+            ).toBundle()
+        )
     }
 
     private fun showSaveDialog(selectCount: Int) {

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/ui/searchimage/SearchQueryViewHolder.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/ui/searchimage/SearchQueryViewHolder.kt
@@ -32,6 +32,10 @@ class SearchQueryViewHolder private constructor(
             return binding.etQuery.text.toString()
         }
 
+    fun clearFocus(){
+        binding.etQuery.clearFocus()
+    }
+
     fun bind(query: SearchImageListTypeModel.Query) {
         binding.holder = this
         bindQuery(query)

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/GalleryViewModel.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/GalleryViewModel.kt
@@ -202,7 +202,8 @@ class GalleryViewModel @Inject constructor(
         when (selectMode.value) {
             true ->
                 setSelectImage(image, idx, !selectImageHashMap.containsKey(image.hash))
-            else -> {}
+            else ->
+                _uiEvent.value = SingleEvent(UiEvent.NavigateImageDetail(image.imageUrl, idx))
         }
     }
 
@@ -247,7 +248,7 @@ class GalleryViewModel @Inject constructor(
     }
 
     private fun showSnackBar(message: String, action: Pair<String, () -> Unit>?) {
-        _uiEvent.value = SingleEvent(GalleryViewModel.UiEvent.ShowSnackBar(message, action))
+        _uiEvent.value = SingleEvent(UiEvent.ShowSnackBar(message, action))
     }
 
     private fun setNotifyGroup(visible: Boolean, message: String, btn: String) {
@@ -267,7 +268,8 @@ class GalleryViewModel @Inject constructor(
         data class ShowSnackBar(val message: String, val action: (Pair<String, ()->Unit>)?) : UiEvent()
         data class PresentRemoveDialog(val selectCount: Int) : UiEvent()
         data class KeyboardVisibleEvent(val visible: Boolean) : UiEvent()
-        object NavigateSearchView : UiEvent()
         data class ScrollToTop(val smoothScroll: Boolean) : UiEvent()
+        object NavigateSearchView : UiEvent()
+        data class NavigateImageDetail(val imageUrl: String, val position: Int) : UiEvent()
     }
 }

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/ImageDetailViewModel.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/ImageDetailViewModel.kt
@@ -1,0 +1,66 @@
+package com.gallery.kakaogallery.presentation.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class ImageDetailViewModel @Inject constructor(
+    private val handle: SavedStateHandle
+) : ViewModel() {
+
+    companion object {
+        private const val KEY_IMAGE_URL = "key_image_url"
+        const val EXTRA_IMAGE_DETAIL = "extra_image_detail"
+    }
+
+    /**
+     * loadInfo.first => url
+     * loadInfo.second => cache
+     * 이미지가 로딩이 늦어질 경우를 대비해, 캐시에서 이미지를 우선 검색
+     */
+    private val _imageUrl: MutableLiveData<String> = handle.getLiveData(KEY_IMAGE_URL)
+    val imageUrl: LiveData<String> = _imageUrl
+
+    private val _loadOnlyCache = MutableLiveData(true)
+    val loadOnlyCache: LiveData<Boolean> = _loadOnlyCache
+
+    private val _uiEvent: MutableLiveData<SingleEvent<UiEvent>> = MutableLiveData()
+    val uiEvent: LiveData<SingleEvent<UiEvent>> = _uiEvent
+
+    private var prevLoadSuccess = false
+
+    init {
+        for(key in handle.keys()){
+            when (key) {
+                EXTRA_IMAGE_DETAIL -> { // 캐시에서 썸네일을 우선 load
+                    when (handle.get<String>(key)) {
+                        null -> _uiEvent.value = SingleEvent(UiEvent.Dismiss)
+                        else -> _imageUrl.value = handle[key]
+                    }
+                }
+            }
+        }
+    }
+
+    fun reloadIfCacheLoadFail() {
+        if(loadOnlyCache.value == true && !prevLoadSuccess) {
+            _loadOnlyCache.value = false
+        }
+    }
+
+    val finishLoadImageEvent: (Boolean) -> Unit = {
+        Timber.d("animation debug => finishLoadImageEvent[$it]")
+        prevLoadSuccess = it
+        _uiEvent.value = SingleEvent(UiEvent.PostLoadImage)
+    }
+
+    sealed class UiEvent {
+        object PostLoadImage : UiEvent()
+        object Dismiss : UiEvent()
+    }
+}

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/ImageDetailViewModel.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/ImageDetailViewModel.kt
@@ -56,7 +56,7 @@ class ImageDetailViewModel @Inject constructor(
     }
 
     fun reloadIfCacheLoadFail() {
-        if(imageUrl.value?.endsWith(".gif") == true || loadOnlyCache.value == true && !prevLoadSuccess) {
+        if(loadOnlyCache.value == true && !prevLoadSuccess) {
             _loadOnlyCache.value = false
         }
     }

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/ImageDetailViewModel.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/ImageDetailViewModel.kt
@@ -48,7 +48,7 @@ class ImageDetailViewModel @Inject constructor(
     }
 
     fun reloadIfCacheLoadFail() {
-        if(loadOnlyCache.value == true && !prevLoadSuccess) {
+        if(imageUrl.value?.endsWith(".gif") == true || loadOnlyCache.value == true && !prevLoadSuccess) {
             _loadOnlyCache.value = false
         }
     }

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/ImageDetailViewModel.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/ImageDetailViewModel.kt
@@ -15,6 +15,7 @@ class ImageDetailViewModel @Inject constructor(
 
     companion object {
         private const val KEY_IMAGE_URL = "key_image_url"
+        private const val KEY_IMAGE_FULL_SCREEN_MODE = "key_image_full_screen_mode"
         const val EXTRA_IMAGE_DETAIL = "extra_image_detail"
     }
 
@@ -28,6 +29,9 @@ class ImageDetailViewModel @Inject constructor(
 
     private val _loadOnlyCache = MutableLiveData(true)
     val loadOnlyCache: LiveData<Boolean> = _loadOnlyCache
+
+    private val _fullScreenMode: MutableLiveData<Boolean> = handle.getLiveData(KEY_IMAGE_FULL_SCREEN_MODE, false)
+    val fullScreenMode: LiveData<Boolean> = _fullScreenMode
 
     private val _uiEvent: MutableLiveData<SingleEvent<UiEvent>> = MutableLiveData()
     val uiEvent: LiveData<SingleEvent<UiEvent>> = _uiEvent
@@ -45,6 +49,10 @@ class ImageDetailViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    fun touchBackgroundEvent() {
+        _fullScreenMode.value = !(fullScreenMode.value ?: false)
     }
 
     fun reloadIfCacheLoadFail() {

--- a/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/SearchImageViewModel.kt
+++ b/app/src/main/java/com/gallery/kakaogallery/presentation/viewmodel/SearchImageViewModel.kt
@@ -317,7 +317,8 @@ class SearchImageViewModel @Inject constructor(
         when (selectMode.value) {
             true ->
                 setSelectImage(image, idx, !selectImageUrlMap.containsKey(image.imageUrl))
-            else -> {}
+            else ->
+                _uiEvent.value = SingleEvent(UiEvent.NavigateImageDetail(image.imageUrl, idx))
         }
     }
 
@@ -356,5 +357,6 @@ class SearchImageViewModel @Inject constructor(
         data class PresentSaveDialog(val selectCount: Int) : UiEvent()
         data class KeyboardVisibleEvent(val visible: Boolean) : UiEvent()
         data class ScrollToTop(val smoothScroll: Boolean) : UiEvent()
+        data class NavigateImageDetail(val imageUrl: String, val position: Int) : UiEvent()
     }
 }

--- a/app/src/main/res/layout/activity_image_detail.xml
+++ b/app/src/main/res/layout/activity_image_detail.xml
@@ -10,20 +10,23 @@
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".presentation.ui.imagedetail.ImageDetailActivity">
+        tools:context=".presentation.ui.imagedetail.ImageDetailActivity"
+        android:id="@+id/background"
+        >
 
         <com.google.android.material.appbar.AppBarLayout xmlns:android="http://schemas.android.com/apk/res/android"
             xmlns:app="http://schemas.android.com/apk/res-auto"
             android:id="@+id/layout_app_bar"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:background="#FFFFFF"
+            android:background="@color/black_222222"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             >
 
             <com.google.android.material.appbar.MaterialToolbar
+                app:navigationIconTint="@color/white_ffffff"
                 android:id="@+id/tool_bar"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
@@ -32,6 +35,7 @@
         </com.google.android.material.appbar.AppBarLayout>
 
         <ImageView
+            android:background="@color/black_000000"
             app:loadOnlyCache="@{viewModel.loadOnlyCache}"
             app:loadUrl="@{viewModel.imageUrl}"
             app:loadUrlFinishListener="@{viewModel.finishLoadImageEvent}"

--- a/app/src/main/res/layout/activity_image_detail.xml
+++ b/app/src/main/res/layout/activity_image_detail.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+    <data>
+        <variable
+            name="viewModel"
+            type="com.gallery.kakaogallery.presentation.viewmodel.ImageDetailViewModel" />
+    </data>
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.ui.imagedetail.ImageDetailActivity">
+
+        <com.google.android.material.appbar.AppBarLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            android:id="@+id/layout_app_bar"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="#FFFFFF"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            >
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/tool_bar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                />
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <ImageView
+            app:loadOnlyCache="@{viewModel.loadOnlyCache}"
+            app:loadUrl="@{viewModel.imageUrl}"
+            app:loadUrlFinishListener="@{viewModel.finishLoadImageEvent}"
+            android:scaleType="fitCenter"
+            android:id="@+id/ivImage"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/transition/transition_image_detail.xml
+++ b/app/src/main/res/transition/transition_image_detail.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    changeImageTransform
+    This Transition captures an ImageView's matrix before and after the scene change and animates it during the transition
+    In combination with ChangeBounds, ChangeImageTransform allows ImageViews that change size, shape, or ImageView.ScaleType to animate contents smoothly.
+
+    changeBounds
+    This transition captures the layout bounds of target views before and after the scene change and animates those changes during the transition.
+-->
+<transitionSet xmlns:android="http://schemas.android.com/apk/res/android">
+    <changeBounds />
+    <changeImageTransform />
+</transitionSet>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -12,6 +12,10 @@
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">#BFC1C3</item>
         <!-- Customize your theme here. -->
+        <item name="android:windowSharedElementEnterTransition">
+            @transition/transition_image_detail</item>
+        <item name="android:windowSharedElementExitTransition">
+            @transition/transition_image_detail</item>
     </style>
 
     <!-- Bottom Sheet Radius -->

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -17,28 +17,4 @@
         <item name="android:windowSharedElementExitTransition">
             @transition/transition_image_detail</item>
     </style>
-
-    <!-- Bottom Sheet Radius -->
-    <style name="CustomBottomSheetDialog" parent="@style/ThemeOverlay.MaterialComponents.BottomSheetDialog">
-        <item name="bottomSheetStyle">@style/CustomBottomSheet</item>
-    </style>
-
-    <style name="CustomBottomSheet" parent="Widget.MaterialComponents.BottomSheet">
-        <item name="shapeAppearanceOverlay">@style/CustomShapeAppearanceBottomSheetDialog</item>
-    </style>
-
-    <style name="CustomShapeAppearanceBottomSheetDialog" parent="">
-        <item name="cornerFamily">rounded</item>
-        <item name="cornerSizeTopRight">15dp</item>
-        <item name="cornerSizeTopLeft">15dp</item>
-        <item name="cornerSizeBottomRight">0dp</item>
-        <item name="cornerSizeBottomLeft">0dp</item>
-    </style>
-
-    <style name="Theme.KakaoGallery.Splash" parent="Theme.SplashScreen">
-        <item name="windowSplashScreenBackground">@color/yellow_f1eb52</item>
-        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_app_logo</item>
-        <item name="windowSplashScreenAnimationDuration">1000</item>
-        <item name="postSplashScreenTheme">@style/Theme.KakaoGallery</item>
-    </style>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,6 +6,7 @@
     <color name="teal_200">#FF03DAC5</color>
     <color name="teal_700">#FF018786</color>
     <color name="black_000000">#FF000000</color>
+    <color name="black_222222">#222222</color>
     <color name="white_ffffff">#FFFFFFFF</color>
 
     <color name="gold_aa9763">#aa9763</color>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -12,6 +12,10 @@
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">#BFC1C3</item>
         <!-- Customize your theme here. -->
+        <item name="android:windowSharedElementEnterTransition">
+            @transition/transition_image_detail</item>
+        <item name="android:windowSharedElementExitTransition">
+            @transition/transition_image_detail</item>
     </style>
 
     <!-- Bottom Sheet Radius -->

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -10,12 +10,17 @@
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black_000000</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">#BFC1C3</item>
+        <item name="android:statusBarColor">#BFC1C3</item>
         <!-- Customize your theme here. -->
         <item name="android:windowSharedElementEnterTransition">
             @transition/transition_image_detail</item>
         <item name="android:windowSharedElementExitTransition">
             @transition/transition_image_detail</item>
+    </style>
+
+    <style name="Theme.ImageDetail" parent="Theme.AppCompat.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@color/black_222222</item>
+        <item name="android:windowLightStatusBar">false</item>
     </style>
 
     <!-- Bottom Sheet Radius -->


### PR DESCRIPTION
## 📪  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #102 
## 📚  What's-New
<!-- 한 일들을 적어주세요. -->
- [x]  ImageDetail 화면 구현
- [x]  이미지 자세히 보기 모드 구현(fullScreenMode)
    - 터치에 따라 systemBar 유무 설정
- [x]  화면 전환간에 Shared Element Animation 적용
    - [x]  shared element transition 시에 이미지 load delay발생 문제 해결
    - [x]  Search화면에서 EditText가 보이는 상태에서 ImageDetail에 다녀오면, Focus가 EditText에 돌아오면서 키보드가 올라오는 문제 해결
    - [x]  동시에 여러 itemView 선택, itemView 더블 클릭 방지
    - [x]  gif파일 처리
- [x]  PinchZoom 구현

closed #102 